### PR TITLE
Make new update signing key import compatible with dash

### DIFF
--- a/keys/keys.sh
+++ b/keys/keys.sh
@@ -16,11 +16,14 @@ done
 rm "$new_keylist"
 
 # Import new keys
+current_keylist="$(mktemp)"
+echo "$current_keys" > "$current_keylist"
 for keyfile in keys/*.asc; do
     keyid="$(gpg --with-colons "$keyfile" 2>/dev/null | grep '^pub' | cut -d: -f5)"
-    if ! grep -qs "$keyid" <<< "$current_keys"; then
+    if ! grep -qs "$keyid" "$current_keylist"; then
         echo "Importing key $keyid from $keyfile..."
         gpg --import "$keyfile"
         echo -e "trust\n5\ny\n" | gpg --batch --no-tty --command-fd 0 --expert --edit-key "$keyid"
     fi
 done
+rm "$current_keylist"


### PR DESCRIPTION
Before these changes it worked only with bash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the method for checking existing GPG key IDs by switching from an in-memory search to a file-based search within the script. This does not impact the overall workflow or visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->