### PR TITLE
lnd: update from 0.18.5 to 0.19.1

### DIFF
--- a/lnd/env
+++ b/lnd/env
@@ -1,6 +1,6 @@
-LND_VERSION_DIR_AARCH64=lnd-linux-arm64-v0.18.5-beta
-LND_URL_AARCH64=https://github.com/lightningnetwork/lnd/releases/download/v0.18.5-beta/lnd-linux-arm64-v0.18.5-beta.tar.gz
-LND_SHA256_AARCH64=2b3512746a1583c67c585436282ab84fb483bdee3815954d170e39ccfbb3942c
+LND_VERSION_DIR_AARCH64=lnd-linux-arm64-v0.19.1-beta
+LND_URL_AARCH64=https://github.com/lightningnetwork/lnd/releases/download/v0.19.1-beta/lnd-linux-arm64-v0.19.1-beta.tar.gz
+LND_SHA256_AARCH64=a541ce7eb2cb4e3c3482625d3420c6de9babedffbddf31bfdf9e2e4f1a9ab08a
 
 # binaries and config root; data is elsewhere, in /ssd/lnd as per lnd conf.
 LND_HOME=/home/lnd
@@ -11,12 +11,12 @@ lnd_bin_install() {
     cd $LND_HOME
     local lnd_targz=$LND_VERSION_DIR_AARCH64.tar.gz
     test -f $LND_VERSION_DIR_AARCH64/lnd && return 0;
-    curl -sSL -o $lnd_targz "$LND_URL_AARCH64"
+    curl -fSL -o $lnd_targz "$LND_URL_AARCH64"
     if [ $? -ne 0 ]; then
         printf "ERROR: unable to download $LND_URL_AARCH64\n" 1>&2
         return 1
     fi
-    printf "$LND_SHA256_AARCH64 $lnd_targz" | sha256sum --check
+    printf '%s  %s\n' "$LND_SHA256_AARCH64" "$lnd_targz" | sha256sum --check
     [ $? -ne 0 ] && return 1
     tar -C $LND_HOME --no-same-owner -xf $lnd_targz
     rm -f $lnd_targz


### PR DESCRIPTION
Resolves #16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the LND version for ARM64 architecture to 0.19.1-beta, including download URL and checksum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->