### PR TITLE
Allow updating /boot/config.txt and /boot/cmdline.txt from latest img versions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "img"]
+	path = img
+	url = https://github.com/nakamochi/img

--- a/apply.sh
+++ b/apply.sh
@@ -18,6 +18,9 @@ cd "$rootdir" || exit 1
 ./keys/keys.sh || exit 1
 
 # base os
+printf "######## boot\n" 1>&2
+cd "$rootdir" || exit 1
+./base/boot.sh || exit 1
 printf "######## base os\n" 1>&2
 cd "$rootdir" || exit 1
 ./base/voidlinux.sh || exit 1

--- a/base/boot.sh
+++ b/base/boot.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# this one requires bash, will not work with dash:
+set -euo pipefail
+
+BOOT_FILES_SOURCE="img/rootfiles/boot"
+BOOT_FILES_TARGET="/boot"
+
+if [ -f $BOOT_FILES_SOURCE/cmdline.txt ] && [ -f $BOOT_FILES_SOURCE/config.txt ]; then
+    # cp overwrites in-place; if the write is interrupted you may leave
+    # /boot/config.txt empty and render the device unbootable. Use an atomic
+    # move.
+    # Also diff first to not do extra wear with unnecessary writes to uSD card.
+    for fn in cmdline.txt config.txt; do
+        if ! diff "${BOOT_FILES_SOURCE}/${fn}" "${BOOT_FILES_TARGET}/${fn}"; then
+            echo "Updating ${BOOT_FILES_TARGET}/${fn}"
+            cp "${BOOT_FILES_SOURCE}/${fn}" "${BOOT_FILES_TARGET}/${fn}.new"
+            mv "${BOOT_FILES_TARGET}/${fn}.new" "${BOOT_FILES_TARGET}/${fn}"
+        fi
+    done
+fi

--- a/update.sh
+++ b/update.sh
@@ -41,6 +41,7 @@ if ! {
     git clean -fd &&             # force-delete untracked files
     git checkout "$BRANCH" &&
     git pull --verify-signatures
+    git submodule update --init --recursive
 } >> "$LOGFILE" 2>&1 ; then
     echo "ERROR: git pull failed"
     cat "$LOGFILE"


### PR DESCRIPTION
Git submodules are introduced so that we use version from https://github.com/nakamochi/img directly and not doing unnecessary copy/paste all the time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage boot configuration files atomically, updating only when changes are detected for safer upgrades.
  * Support inclusion and tracking of an external image repository via a new submodule.

* **Chores**
  * Automatically initialise and update all submodules after pulling updates.
  * Added a dedicated boot step to the update sequence to ensure boot files are applied early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->