### PR TITLE
lnd: update from 0.19.2 to 0.19.3

### DIFF
--- a/lnd/env
+++ b/lnd/env
@@ -1,10 +1,10 @@
 #!/bin/sh
 # shellcheck disable=SC2015,SC3043
 
-LND_VERSION=0.19.2
+LND_VERSION=0.19.3
 LND_VERSION_DIR_AARCH64=lnd-linux-arm64-v$LND_VERSION-beta
 LND_URL_AARCH64=https://github.com/lightningnetwork/lnd/releases/download/v$LND_VERSION-beta/lnd-linux-arm64-v$LND_VERSION-beta.tar.gz
-LND_SHA256_AARCH64=2940770b0c8da7c9ed876d2d1617aae092f8cd0ba237ca6fa0d677406b12034b
+LND_SHA256_AARCH64=4c454636c92c555b18393f9c4107d34d8826173651e980f6857ec33307bd0c87
 
 # binaries and config root; data is elsewhere, in /ssd/lnd as per lnd conf.
 LND_HOME=/home/lnd


### PR DESCRIPTION
This third minor release contains important bug fixes to improve p2p stability, a retry bug in path finding, and adds improved isolation to anchor sweeping on chain.

https://github.com/lightningnetwork/lnd/blob/0-19-3-branch/docs/release-notes/release-notes-0.19.3.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the Lightning Network Daemon to version 0.19.3, primarily affecting AArch64 builds. This update fetches the latest upstream binary and refreshes integrity verification. Users on supported devices will receive the new runtime after updating. No UI changes; existing Lightning functionality continues to operate with the updated backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->