### PR TITLE
Don't update git submodules if git pull fails

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -40,10 +40,11 @@ if ! {
     git reset --hard HEAD &&     # remove local changes
     git clean -fd &&             # force-delete untracked files
     git checkout "$BRANCH" &&
-    git pull --verify-signatures
+    git pull --verify-signatures &&
+    git submodule sync --recursive &&
     git submodule update --init --recursive
 } >> "$LOGFILE" 2>&1 ; then
-    echo "ERROR: git pull failed"
+    echo "ERROR: repository update failed"
     cat "$LOGFILE"
     exit 1
 fi


### PR DESCRIPTION
Without this, if git pull fails, but submodule update afterwards succeeds, script will not terminate with error and continue, which is not what is expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update process now ensures dependent repository steps only run after a successful fetch, preventing partial or inconsistent states.
  * Added synchronization of linked repositories as part of the conditional update flow for more reliable multi-repo updates.
  * Improved error messaging on update failure to make issues clearer to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->