### PR TITLE
ndg: update to v0.8.2 and add gpg signature verify

### DIFF
--- a/ndg/env
+++ b/ndg/env
@@ -1,9 +1,9 @@
 #!/bin/sh
 # shellcheck disable=SC2015,SC3043
 
-NDG_VERSION=v0.8.1
-NDG_URL_AARCH64=https://github.com/nakamochi/ndg/releases/download/v0.8.1/ndg-v0.8.1-aarch64.tar.gz
-NDG_SHA256_AARCH64=d67fd26149dd13900125a6ebfc527028110f8f71dfb2ae311f7a9ca0f99ceff0
+NDG_VERSION=v0.8.2
+NDG_URL_AARCH64=https://github.com/nakamochi/ndg/releases/download/$NDG_VERSION/ndg-$NDG_VERSION-aarch64.tar.gz
+NDG_SHA256_AARCH64=662e8931e45b6e82cedc0c6618177ba97e4ada3b5e162132efef114eb9120651
 
 NDG_HOME=/home/uiuser
 NDG_BINDIR=$NDG_HOME/$NDG_VERSION
@@ -16,10 +16,15 @@ ndg_bin_install() {
         printf "ERROR: unable to download %s\n" "$NDG_URL_AARCH64" 1>&2
         return 1
     fi
+    if ! curl -sSL -o "$targz.asc" "$NDG_URL_AARCH64.asc"; then
+        printf "ERROR: unable to download %s\n" "$NDG_URL_AARCH64.asc" 1>&2
+        return 1
+    fi
     printf "%s %s" "$NDG_SHA256_AARCH64" "$targz" | sha256sum --check || return 1
+    gpg --verify "$targz.asc" "$targz" || return 1
     mkdir -p $NDG_BINDIR
     tar -C $NDG_BINDIR --no-same-owner -xf "$targz"
-    rm -f "$targz"
+    rm -f "$targz" "$targz.asc"
     return $?
 }
 


### PR DESCRIPTION
https://github.com/nakamochi/ndg/releases/tag/v0.8.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added cryptographic signature retrieval and GPG verification for downloaded AArch64 binaries, in addition to existing SHA-256 checks; installation now fails if signature verification fails.
  - Cleans up downloaded tarball and signature after installation.

- Chores
  - Bumped NDG version to v0.8.2.
  - Updated AArch64 download URL handling and checksum to match the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->