### PR TITLE
btc: upgrade bitcoind from 29.1 to 29.2

### DIFF
--- a/btc/env
+++ b/btc/env
@@ -1,10 +1,10 @@
 #!/bin/sh
 # shellcheck disable=SC2015,SC3043
 
-BITCOIN_CORE_VERSION=29.1
+BITCOIN_CORE_VERSION=29.2
 BITCOIN_CORE_VERSION_DIR_AARCH64=bitcoin-$BITCOIN_CORE_VERSION
 BITCOIN_CORE_URL_AARCH64=https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-aarch64-linux-gnu.tar.gz
-BITCOIN_CORE_SHA256_AARCH64=d6be913e1abc5effe57f50630b4bff2f89b38c092182c47f1fcde0ae12afc71c
+BITCOIN_CORE_SHA256_AARCH64=f88f72a3c5bf526581aae573be8c1f62133eaecfe3d34646c9ffca7b79dfdc7a
 
 # binaries and config root; data is elsewhere, in /ssd/bitcoind as per conf file.
 BITCOIN_HOME=/home/bitcoind


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-29.2.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Upgraded embedded Bitcoin Core to version 29.2 to align with the latest upstream release.
  * Updated ARM64 (AArch64) binary checksum to match the new release, ensuring download verification.
  * No functional changes to application behaviour; maintenance update focused on stability and compatibility.
  * ARM64 users (including Apple Silicon) receive verified binaries with upstream fixes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->