### PR TITLE
ndg: update to v0.8.3

### DIFF
--- a/ndg/env
+++ b/ndg/env
@@ -1,9 +1,9 @@
 #!/bin/sh
 # shellcheck disable=SC2015,SC3043
 
-NDG_VERSION=v0.8.2
+NDG_VERSION=v0.8.3
 NDG_URL_AARCH64=https://github.com/nakamochi/ndg/releases/download/$NDG_VERSION/ndg-$NDG_VERSION-aarch64.tar.gz
-NDG_SHA256_AARCH64=662e8931e45b6e82cedc0c6618177ba97e4ada3b5e162132efef114eb9120651
+NDG_SHA256_AARCH64=13406e87e826db4ec29c93531ee3ad0a0357b8cf6c56eb226c71cadc92fdf8b1
 
 NDG_HOME=/home/uiuser
 NDG_BINDIR=$NDG_HOME/$NDG_VERSION


### PR DESCRIPTION
https://github.com/nakamochi/ndg/releases/tag/v0.8.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled NDG component to version v0.8.3. The download source now points to the latest release, and integrity verification has been refreshed to match the new artefact (including aarch64 builds). This is a transparent maintenance update with no changes to the user interface or workflows. Users can expect routine patch-level improvements in stability and compatibility. No action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->