### PR TITLE
lnd: update from 0.19.3 to 0.20.0

### DIFF
--- a/lnd/env
+++ b/lnd/env
@@ -1,10 +1,10 @@
 #!/bin/sh
 # shellcheck disable=SC2015,SC3043
 
-LND_VERSION=0.19.3
+LND_VERSION=0.20.0
 LND_VERSION_DIR_AARCH64=lnd-linux-arm64-v$LND_VERSION-beta
 LND_URL_AARCH64=https://github.com/lightningnetwork/lnd/releases/download/v$LND_VERSION-beta/lnd-linux-arm64-v$LND_VERSION-beta.tar.gz
-LND_SHA256_AARCH64=4c454636c92c555b18393f9c4107d34d8826173651e980f6857ec33307bd0c87
+LND_SHA256_AARCH64=e4fb51cadd5d2a8d7bc6c4f834abf4605c89d361da328a0948e65fb7036d732a
 
 # binaries and config root; data is elsewhere, in /ssd/lnd as per lnd conf.
 LND_HOME=/home/lnd


### PR DESCRIPTION
Among other improvements and bugfixes, this migrates the graph store from the KV format to native SQL.

https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.20.0.md

Resolves https://github.com/nakamochi/img/issues/5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded LND from v0.19.3 to v0.20.0 and updated the ARM64 verification hash to match the new release. No functional or behavioural changes; download locations and naming remain unchanged.

<sub>✏️ Tip: You can customise this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->