### PR TITLE
get rid of bash requirement in base/boot.sh

### DIFF
--- a/base/boot.sh
+++ b/base/boot.sh
@@ -1,7 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-# this one requires bash, will not work with dash:
-set -euo pipefail
+set -eu
 
 BOOT_FILES_SOURCE="img/rootfiles/boot"
 BOOT_FILES_TARGET="/boot"


### PR DESCRIPTION
Don't see how `set -o pipefail` is necessary here. It was added as a precausion, but that introduced unnecessary dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved boot script shell compatibility across a wider range of system environments and streamlined configuration for enhanced startup reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->