### PR TITLE
ci: check last git commit signature against trusted keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,5 +5,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+      - name: Check last git commit signature against trusted keys
+        run: bash -x ./test/check-last-commit-signature-key.sh

--- a/test/check-last-commit-signature-key.sh
+++ b/test/check-last-commit-signature-key.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# check that last git commit is signed and signer's key is present in keys directory
+
+cd "$(dirname "$0")" || exit 1
+
+last_commit_key_id="$(git log --no-merges --show-signature | grep -E "using [A-Za-z0-9]+ key" | head -n 1 | tail -c 17)"
+
+if [ -z "$last_commit_key_id" ]; then
+    echo "Last commit is not signed"
+    exit 1
+fi
+
+for keyfile in ../keys/*.asc; do
+    keyid="$(gpg --with-colons "$keyfile" 2>/dev/null | grep '^pub' | cut -d: -f5)"
+    if [ "$keyid" = "$last_commit_key_id" ]; then
+        echo "Last commit is signed with a known key: $last_commit_key_id"
+        exit 0
+    fi
+done
+
+echo "Last commit is signed with an unknown key: $last_commit_key_id"
+exit 1


### PR DESCRIPTION
Resolves #10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow to fetch full git history and run an additional verification step during builds.
* **Tests**
  * Added a verification that the most recent commit is GPG-signed and that the signer matches a trusted key, failing the run if unsigned or unknown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->