### PR TITLE
move sysupdate.log to ssd

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -15,7 +15,7 @@ REMOTE_URL="${2:-https://github.com/nakamochi/sysupdates.git}"
 # output everything to a temp file and print its contents only in case of an error,
 # so that when run via a cronjob, the output is empty on success which prevents
 # needless emails, were any configured.
-LOGFILE="${LOGFILE:-/var/log/sysupdate.log}"
+LOGFILE="${LOGFILE:-/ssd/sysupdate.log}"
 # a local git repo dir where to pull the updates into.
 REPODIR="${REPODIR:-/ssd/sysupdates}"
 


### PR DESCRIPTION
To reduce unnecessary wear on uSD card.

Resolves #42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default system update log location changed from /var/log/sysupdate.log to /ssd/sysupdate.log.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->