### PR TITLE
avoid unnecessary rewrites of CLI scripts

### DIFF
--- a/btc/env
+++ b/btc/env
@@ -1,6 +1,9 @@
 #!/bin/sh
 # shellcheck disable=SC2015,SC3043
 
+# shellcheck source=lib/files.sh
+. "$SYSUPDATES_ROOTDIR/lib/files.sh"
+
 BITCOIN_CORE_VERSION=29.2
 BITCOIN_CORE_VERSION_DIR_AARCH64=bitcoin-$BITCOIN_CORE_VERSION
 BITCOIN_CORE_URL_AARCH64=https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-aarch64-linux-gnu.tar.gz
@@ -53,8 +56,13 @@ EOF
 }
 
 bitcoin_cli_install() {
-    mkdir -p /opt/bin
-    cat <<EOF > /opt/bin/bitcoin-cli.sh
+    tmp="$(mktemp /run/bitcoin-cli.sh.XXXXXX)" || return 1
+    mkdir -p /opt/bin || {
+    	rm -f "$tmp"
+    	return 1
+	}
+
+    if ! cat > "$tmp" <<EOF
 #!/bin/sh
 set -eu
 CLI=$BITCOIN_HOME/$BITCOIN_CORE_VERSION_DIR_AARCH64/bin/bitcoin-cli
@@ -62,7 +70,12 @@ DATA=/ssd/bitcoind/mainnet
 CHAIN=main
 exec doas -u bitcoind \$CLI -datadir=\$DATA -chain=\$CHAIN "\$@"
 EOF
-    chmod +x /opt/bin/bitcoin-cli.sh
+    then
+        rm -f "$tmp"
+        return 1
+    fi
+
+    write_if_changed "$tmp" /opt/bin/bitcoin-cli.sh 0755 || return 1
 }
 
 bitcoin_apply() {

--- a/lib/files.sh
+++ b/lib/files.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=sh
+
+write_if_changed() {
+    src="$1"
+    dst="$2"
+    mode="$3"
+
+    chmod "$mode" "$src" || {
+        rm -f "$src"
+        return 1
+    }
+
+    if test -f "$dst" && cmp -s "$dst" "$src"; then
+        rm -f "$src"
+        return 0
+    fi
+
+    mv "$src" "$dst" || {
+        rm -f "$src"
+        return 1
+    }
+
+    return 0
+}

--- a/lnd/env
+++ b/lnd/env
@@ -1,6 +1,9 @@
 #!/bin/sh
 # shellcheck disable=SC2015,SC3043
 
+# shellcheck source=lib/files.sh
+. "$SYSUPDATES_ROOTDIR/lib/files.sh"
+
 LND_VERSION=0.20.1
 LND_VERSION_DIR_AARCH64=lnd-linux-arm64-v$LND_VERSION-beta
 LND_URL_AARCH64=https://github.com/lightningnetwork/lnd/releases/download/v$LND_VERSION-beta/lnd-linux-arm64-v$LND_VERSION-beta.tar.gz
@@ -65,14 +68,24 @@ EOF
 }
 
 lnd_cli_install() {
-    mkdir -p /opt/bin
-    cat <<EOF > /opt/bin/lncli.sh
+    tmp="$(mktemp /run/lncli.sh.XXXXXX)" || return 1
+    mkdir -p /opt/bin || {
+        rm -f "$tmp"
+        return 1
+    }
+
+    if ! cat > "$tmp" <<EOF
 #!/bin/sh
 set -e
 cli=$LND_HOME/$LND_VERSION_DIR_AARCH64/lncli
 exec doas -u lnd \$cli --macaroonpath /ssd/lnd/data/chain/bitcoin/mainnet/admin.macaroon "\$@"
 EOF
-    chmod +x /opt/bin/lncli.sh
+    then
+        rm -f "$tmp"
+        return 1
+    fi
+
+    write_if_changed "$tmp" /opt/bin/lncli.sh 0755 || return 1
 }
 
 lnd_apply() {


### PR DESCRIPTION
generate temp files in `/run` and only update `/opt/bin/*.sh` if content changed using new `write_if_changed()` helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardised and improved the installation process for command-line tools by introducing a shared utility function. Enhanced error handling and automatic cleanup of temporary files on failures. Added intelligent content comparison to prevent unnecessary file updates, resulting in more reliable and efficient system deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->