### PR TITLE
cron: enforce custom svlogd settings after xbps self-update

### DIFF
--- a/base/voidlinux.sh
+++ b/base/voidlinux.sh
@@ -61,6 +61,22 @@ if [ ! -f /etc/cron.daily/xbps-selfupdate ]; then
     cat <<EOF >/etc/cron.daily/xbps-selfupdate
 #!/bin/sh
 BACKUP_XBPS="/usr/local/bin/xbps-install.static"
+ensure_socklog_tweaks() {
+    tmp_run=\$(mktemp)
+    cat >"\$tmp_run" <<'EOFX'
+#!/bin/sh
+exec svlogd -tt -b 65536 -l 2000 /var/log/socklog/\* #2>/dev/tty12
+EOFX
+    if [ -f /etc/sv/socklog-unix/log/run ] && cmp -s "\$tmp_run" /etc/sv/socklog-unix/log/run; then
+        rm -f "\$tmp_run"
+        return 0
+    fi
+    chmod 755 "\$tmp_run"
+    mv "\$tmp_run" /etc/sv/socklog-unix/log/run
+    if sv status socklog-unix >/dev/null 2>&1; then
+        sv restart socklog-unix/log
+    fi
+}
 if [ -z "\$XBPS_SELFUPDATE_LOCK" ]; then
     lockfile=/run/lock/xbps-selfupdate.lock
     exec env XBPS_SELFUPDATE_LOCK=1 \\
@@ -75,11 +91,13 @@ if [ "\$installed_ver" = "\$repo_ver" ]; then
 fi
 if xbps-install -uy xbps; then
     xbps-install -Suy
+    ensure_socklog_tweaks
     exit 0
 fi
 if [ -x "\$BACKUP_XBPS" ]; then
     \$BACKUP_XBPS -uy xbps &&
-    xbps-install -Suy
+    xbps-install -Suy &&
+    ensure_socklog_tweaks
 fi
 EOF
     chmod +x /etc/cron.daily/xbps-selfupdate


### PR DESCRIPTION
Ensure that socklog svlogd configuration is preserved across system updates by rewriting /etc/sv/socklog-unix/log/run after any successful xbps-install -Suy invocation.

Add ensure_socklog_tweaks() helper to:
- restore desired svlogd flags:
    -tt        enable timestamps (reduced from -ttt)
    -b 65536   enable 64KB RAM buffering to reduce SD card writes
    -l 2000    increase max log line length
- preserve literal wildcard path (/var/log/socklog/*) using escaping
- restart socklog-unix/log service if running

Invoke helper after:
- successful xbps self-update + full system update
- fallback static xbps update path

Rationale:
xbps updates may overwrite /etc/sv/socklog-unix/log/run with default settings (no buffering), leading to excessive write amplification on SD-backed systems. This ensures persistent low-write logging behavior without manual intervention.

Trade-off:
svlogtail output may be slightly delayed due to buffering, but observed latency remains low (~1s) and acceptable.

Handles https://github.com/nakamochi/img/pull/46 in sysupdates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to latest versions
  * Enhanced system maintenance automation to reliably update logging runtime scripts and restart logging services when needed during package updates
  * Updated an embedded image component to a newer revision
<!-- end of auto-generated comment: release notes by coderabbit.ai -->