### PR TITLE
Update NDG to v0.9.2

### DIFF
--- a/ndg/env
+++ b/ndg/env
@@ -1,9 +1,9 @@
 #!/bin/sh
 # shellcheck disable=SC2015,SC3043
 
-NDG_VERSION=v0.9.1
+NDG_VERSION=v0.9.2
 NDG_URL_AARCH64=https://github.com/nakamochi/ndg/releases/download/$NDG_VERSION/ndg-$NDG_VERSION-aarch64.tar.gz
-NDG_SHA256_AARCH64=fad039f9b082ff97059eb25b28e9a14699f63a2abedf58d872a2b395d5879a29
+NDG_SHA256_AARCH64=98628480d81cae4b1b896d27cd48c28b78eaccf4338a9a9d7d0e345d5e9314b2
 
 NDG_HOME=/home/uiuser
 NDG_BINDIR=$NDG_HOME/$NDG_VERSION


### PR DESCRIPTION
Fixed wallet recovery.

Full release notes: https://github.com/nakamochi/ndg/releases/tag/v0.9.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `ndg` release to version `v0.9.2`.
  * Refreshed the AArch64 download checksum so integrity verification matches the newer package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->